### PR TITLE
Fix flavored `base_url` issue

### DIFF
--- a/lib/xmlconv/custom/lookandfeel.rb
+++ b/lib/xmlconv/custom/lookandfeel.rb
@@ -45,6 +45,17 @@ module XmlConv
 			RESOURCES = {
 				:css	=>	'xmlconv.css'
 			}
+
+      alias :orig_base_url :base_url
+
+      # Provides non flavored base url
+      def base_url
+        _flavor = @flavor
+        @flavor = nil
+        url = orig_base_url
+        @flavor = _flavor
+        url
+      end
 		end
 	end
 end

--- a/lib/xmlconv/version.rb
+++ b/lib/xmlconv/version.rb
@@ -1,3 +1,3 @@
 module XmlConv
-  VERSION = '1.0.7'
+  VERSION = '1.0.8'
 end

--- a/test/test_custom/lookandfeel.rb
+++ b/test/test_custom/lookandfeel.rb
@@ -1,0 +1,30 @@
+$: << File.dirname(__FILE__)
+$: << File.expand_path('..', File.dirname(__FILE__))
+$: << File.expand_path('../../lib', File.dirname(__FILE__))
+
+require 'minitest/autorun'
+require 'flexmock/minitest'
+require 'xmlconv/util/application'
+require 'xmlconv/util/session'
+require 'xmlconv/custom/lookandfeel'
+
+module XmlConv
+  class TestApplication < Util::Application
+    def unknown_user; end
+  end
+
+  module Custom
+    class TestLookandfeel < ::Minitest::Test
+      def setup
+        @app     = TestApplication.new
+        @session = Util::Session.new('test', @app)
+      end
+
+      def test_base_url_does_not_include_flavor
+        lookandfeel = Lookandfeel.new(@session)
+        assert_equal('sbsm', lookandfeel.flavor)
+        refute_match(lookandfeel.base_url, @session.flavor)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi @zdavatz @ngiger,

I've fixed flavored (like `/sbsm/`) url issue.
This small change omits **flavor** in `base_url`. :candy: :candy: 

In xmlconv, some views need flavor name. So, I've used arround alias.\
`@flavor` is still there. But It's removed from url :-)
