### PR TITLE
Add charset as UTF-8 in http response header and meta tag

### DIFF
--- a/lib/xmlconv/view/template.rb
+++ b/lib/xmlconv/view/template.rb
@@ -5,13 +5,20 @@ require 'htmlgrid/divtemplate'
 require 'xmlconv/view/foot'
 
 module XmlConv
-	module View
-		class Template < HtmlGrid::DivTemplate
-			COMPONENTS = {
-				[0,0]	=>	:content,
-				[0,1]	=>	:foot,
-			}
-			FOOT = Foot
-		end
-	end
+  module View
+    class Template < HtmlGrid::DivTemplate
+      HTTP_HEADERS = {
+        'Content-Type' => 'text/html;charset=UTF-8'
+      }
+      META_TAGS = [{
+        'http-equiv' => 'content-type',
+        'content'    => 'tex/html;charset=UTF-8'
+      }]
+      COMPONENTS = {
+        [0, 0] => :content,
+        [0, 1] => :foot,
+      }
+      FOOT = Foot
+    end
+  end
 end


### PR DESCRIPTION
@zdavatz (cc: @ngiger)

I've added `charset=UTF-8` into http response header and meta tag.
This fixes current strange characters in web ui :wrench: :hammer: 
